### PR TITLE
Add subscription bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,7 @@ func main() {
 	// Wait for stop signal (e.g. ctrl-C)
 	waitForStopSignal()
 	
-	// Unsubscribe and close NATS connection
-	if err := sub.Unsubscribe(); err != nil {
-		log.Errorf("Subscriber could not be unsubscribed: %v", err)
-	}
-	
+	// Unsubscribe to all open subscriptions and close NATS connection
 	if err := conn.Close(); err != nil {
 		log.Errorf("NATS connection could not be closed: %v", err)
 	}

--- a/vnats/subscriber.go
+++ b/vnats/subscriber.go
@@ -18,7 +18,7 @@ type MsgHandler func(data []byte) error
 
 type subscriber struct {
 	conn         *connection
-	subscription *nats.Subscription
+	subscription subscription
 	log          logger.Logger
 	consumerName string
 }

--- a/vnats/subscription_bridge.go
+++ b/vnats/subscription_bridge.go
@@ -1,0 +1,25 @@
+package vnats
+
+import "github.com/nats-io/nats.go"
+
+type subscription interface {
+	Fetch(batch int, opts ...nats.PullOpt) ([]*nats.Msg, error)
+	Unsubscribe() error
+	Drain() error
+}
+type natsSubscription struct {
+	streamSubscription *nats.Subscription
+}
+
+func (s *natsSubscription) Fetch(batch int, opts ...nats.PullOpt) ([]*nats.Msg, error) {
+	return s.streamSubscription.Fetch(batch, opts...)
+}
+
+func (s *natsSubscription) Unsubscribe() error {
+	return s.streamSubscription.Unsubscribe()
+}
+
+func (s *natsSubscription) Drain() error {
+	return s.streamSubscription.Drain()
+
+}


### PR DESCRIPTION
- bridge is used to ease testing by mocking
- connection has now all subscriptions, so it can unsubscribe, drain and close them